### PR TITLE
Fix view mode check

### DIFF
--- a/common/preview.js
+++ b/common/preview.js
@@ -31,7 +31,7 @@ function isIndexInvalid(gallery, index) {
 }
 
 function isInvalidViewMode(viewMode) {
-  return !modes.includes(viewMode);
+  return modes.indexOf(viewMode) < 0;
 }
 
 export function createPreview() {


### PR DESCRIPTION
Invalid mode check was implemented using `includes`
Array method. It is added to array in ES2015 and
seems like it's not supported very well. Temporary
replaced with indexOf check.
