### PR TITLE
Speed up development builds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 # webpack
 webpack.config.js
-webpack.backend.config.js
-webpack.frontend.config.js
+webpack/webpack.backend.config.js
+webpack/webpack.frontend.config.js
 
 # sources
 client/

--- a/client/app.js
+++ b/client/app.js
@@ -38,4 +38,4 @@ app.extend({
   },
 });
 
-domready(app.init.bind(app));
+domready(() => app.init());

--- a/devProxy.js
+++ b/devProxy.js
@@ -4,19 +4,18 @@
  */
 var webpack = require('webpack');
 var WebpackDevServer = require('webpack-dev-server');
-var compilerConfiguration = require('./webpack.config');
+var compilerConfiguration = require('./webpack/frontend.dev');
 
 function start(config) {
   if (config.development) {
     // Development mode
     // Start webpack dev server as proxy for main server
-
-
     var compiler = webpack(compilerConfiguration);
     var devServer = new WebpackDevServer(compiler, {
       contentBase: __dirname + '/dist',
       filename: 'bundle.js',
       inline: true,
+      hot: true,
       proxy: {
         '*': 'http://' + config.host + ':' + config.port,
       },

--- a/devProxy.js
+++ b/devProxy.js
@@ -2,22 +2,32 @@
  * Development server proxy
  * @type {module.exports}
  */
-var webpack = require('webpack');
-var WebpackDevServer = require('webpack-dev-server');
-var compilerConfiguration = require('./webpack/frontend.dev');
+import webpack from 'webpack';
+import WebpackDevServer from  'webpack-dev-server';
+
+import webpackConfig from './webpack/frontend.dev';
+import path from 'path';
+
+const publicPath = '/';
+const contentBase = path.join(__dirname, 'dist');
 
 function start(config) {
   if (config.development) {
     // Development mode
     // Start webpack dev server as proxy for main server
-    var compiler = webpack(compilerConfiguration);
-    var devServer = new WebpackDevServer(compiler, {
-      contentBase: __dirname + '/dist',
-      filename: 'bundle.js',
+    const compiler = webpack(webpackConfig);
+    const serverUrl = `http://${config.host}:${config.port}`;
+
+    const devServer = new WebpackDevServer(compiler, {
+      contentBase,
+      publicPath,
+      filename: 'client.bundle.js',
       inline: true,
-      hot: true,
+      quiet: false,
+      noInfo: true,
+      stats: {colors: true},
       proxy: {
-        '*': 'http://' + config.host + ':' + config.port,
+        '/photos/*': serverUrl,
       },
     });
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "compile": "babel-node node_modules/webpack/bin/webpack.js",
-    "prepublish": "babel-node node_modules/webpack/bin/webpack.js",
+    "prepublish": "rm -rf ./dist && babel-node node_modules/webpack/bin/webpack.js",
     "test": "mocha --compilers js:babel/register test/**/*Test.js",
     "start": "babel-node ./server.js"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-import frontend from './webpack/frontend.js';
+import frontend from './webpack/frontend.prod.js';
 import backend from './webpack/backend.js';
 
 export default [frontend, backend];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-import frontend from './webpack.frontend.config.js';
-import backend from './webpack.backend.config.js';
+import frontend from './webpack/frontend.js';
+import backend from './webpack/backend.js';
 
 export default [frontend, backend];

--- a/webpack/backend.js
+++ b/webpack/backend.js
@@ -1,6 +1,8 @@
 import webpack from 'webpack';
 import fs from 'fs';
-import config from './config.js';
+import path from 'path';
+
+import config from '../config.js';
 
 // workaround to build backend
 var nodeModules = {};
@@ -12,9 +14,11 @@ fs.readdirSync('node_modules')
     nodeModules[mod] = 'commonjs ' + mod;
   });
 
+const cwd = path.join(__dirname, '..');
+
 const sourceDirs = [
-  __dirname + '/common',
-  __dirname + '/server',
+  path.join(cwd, 'common'),
+  path.join(cwd, 'server'),
 ];
 
 export default  {
@@ -24,7 +28,7 @@ export default  {
   target: 'node',
   externals: nodeModules,
   output: {
-    path: __dirname,
+    path: cwd,
     filename: '[name].js',
   },
   module: {

--- a/webpack/frontend.dev.js
+++ b/webpack/frontend.dev.js
@@ -9,7 +9,7 @@ var devConfiguration = Object.assign({},
   baseConfiguration,
   {
     debug: true,
-    devtool: 'cheap-eval-source-map',
+    devtool: 'eval',
   }
 );
 

--- a/webpack/frontend.dev.js
+++ b/webpack/frontend.dev.js
@@ -3,50 +3,18 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
 
 import config from './../config.js';
+import baseConfiguration from './frontend.js';
 
-const webSocketAddress = (config.development)
-  ? '"http://' + config.host + ':' + config.port + '"'
-  : 'window.location.href';
+var devConfiguration = Object.assign({},
+  baseConfiguration,
+  {
+    debug: true,
+    devtool: 'cheap-eval-source-map',
+  }
+);
 
-const cwd = path.join(__dirname, '..');
+devConfiguration.module.loaders.push(
+  {test: /\.(gif|png|jpe?g|svg)$/, loader: 'url?name=[path][name].[ext]?[hash]'}
+);
 
-const sourceDirs = [
-  path.join(cwd, 'client'),
-  path.join(cwd, 'common'),
-];
-
-export default {
-  entry: {
-    client: './client/app',
-  },
-  output: {
-    path: path.join(cwd, 'dist'),
-    filename: '[name].bundle.js',
-  },
-  debug: true,
-  devtool: 'cheap-eval-source-map',
-  module: {
-    preLoaders: [
-      {test: /\.js$/, include: sourceDirs, loader: 'jscs-loader'},
-    ],
-    loaders: [
-      {test: /\.jade$/, loader: 'jade-loader'},
-      {test: /\.scss$/, loader: 'style!css!sass'},
-      {test: /\.js$/, include: sourceDirs, loader: 'babel-loader?optional=runtime'},
-      {test: /\.(gif|png|jpe?g|svg)$/, loaders: [
-        'url?limit=10240&name=[path][name].[ext]?[hash]',
-        'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false',
-      ],},
-    ],
-  },
-  plugins: [
-    new webpack.DefinePlugin({
-      WEBSOCKET_ADDRESS: webSocketAddress,
-    }),
-    new HtmlWebpackPlugin({
-      title: 'Together',
-      template: 'client/index.html',
-      inject: 'body',
-    }),
-  ],
-};
+export default devConfiguration;

--- a/webpack/frontend.dev.js
+++ b/webpack/frontend.dev.js
@@ -1,14 +1,18 @@
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import config from './config.js';
+import path from 'path';
+
+import config from './../config.js';
 
 const webSocketAddress = (config.development)
   ? '"http://' + config.host + ':' + config.port + '"'
   : 'window.location.href';
 
+const cwd = path.join(__dirname, '..');
+
 const sourceDirs = [
-  __dirname + '/client',
-  __dirname + '/common',
+  path.join(cwd, 'client'),
+  path.join(cwd, 'common'),
 ];
 
 export default {
@@ -16,9 +20,11 @@ export default {
     client: './client/app',
   },
   output: {
-    path: __dirname + '/dist',
+    path: path.join(cwd, 'dist'),
     filename: '[name].bundle.js',
   },
+  debug: true,
+  devtool: 'cheap-eval-source-map',
   module: {
     preLoaders: [
       {test: /\.js$/, include: sourceDirs, loader: 'jscs-loader'},
@@ -42,6 +48,5 @@ export default {
       template: 'client/index.html',
       inject: 'body',
     }),
-    new webpack.optimize.UglifyJsPlugin(),
   ],
 };

--- a/webpack/frontend.js
+++ b/webpack/frontend.js
@@ -1,3 +1,8 @@
+/**
+ * Base frontend webpack configuration file.
+ * It should be extended with profile-specific configurations.
+ * Not directly usable.
+ */
 import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
@@ -8,9 +13,9 @@ const webSocketAddress = (config.development)
   ? '"http://' + config.host + ':' + config.port + '"'
   : 'window.location.href';
 
-const cwd = path.join(__dirname, '..');
+export const cwd = path.join(__dirname, '..');
 
-const sourceDirs = [
+export const sourceDirs = [
   path.join(cwd, 'client'),
   path.join(cwd, 'common'),
 ];
@@ -31,10 +36,6 @@ export default {
       {test: /\.jade$/, loader: 'jade-loader'},
       {test: /\.scss$/, loader: 'style!css!sass'},
       {test: /\.js$/, include: sourceDirs, loader: 'babel-loader?optional=runtime'},
-      {test: /\.(gif|png|jpe?g|svg)$/, loaders: [
-        'url?limit=10240&name=[path][name].[ext]?[hash]',
-        'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false',
-      ],},
     ],
   },
   plugins: [
@@ -46,6 +47,5 @@ export default {
       template: 'client/index.html',
       inject: 'body',
     }),
-    new webpack.optimize.UglifyJsPlugin(),
   ],
 };

--- a/webpack/frontend.js
+++ b/webpack/frontend.js
@@ -1,0 +1,51 @@
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+
+import config from './../config.js';
+
+const webSocketAddress = (config.development)
+  ? '"http://' + config.host + ':' + config.port + '"'
+  : 'window.location.href';
+
+const cwd = path.join(__dirname, '..');
+
+const sourceDirs = [
+  path.join(cwd, 'client'),
+  path.join(cwd, 'common'),
+];
+
+export default {
+  entry: {
+    client: './client/app',
+  },
+  output: {
+    path: path.join(cwd, 'dist'),
+    filename: '[name].bundle.js',
+  },
+  module: {
+    preLoaders: [
+      {test: /\.js$/, include: sourceDirs, loader: 'jscs-loader'},
+    ],
+    loaders: [
+      {test: /\.jade$/, loader: 'jade-loader'},
+      {test: /\.scss$/, loader: 'style!css!sass'},
+      {test: /\.js$/, include: sourceDirs, loader: 'babel-loader?optional=runtime'},
+      {test: /\.(gif|png|jpe?g|svg)$/, loaders: [
+        'url?limit=10240&name=[path][name].[ext]?[hash]',
+        'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false',
+      ],},
+    ],
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      WEBSOCKET_ADDRESS: webSocketAddress,
+    }),
+    new HtmlWebpackPlugin({
+      title: 'Together',
+      template: 'client/index.html',
+      inject: 'body',
+    }),
+    new webpack.optimize.UglifyJsPlugin(),
+  ],
+};

--- a/webpack/frontend.prod.js
+++ b/webpack/frontend.prod.js
@@ -1,0 +1,21 @@
+import webpack from 'webpack';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+
+import config from './../config.js';
+import baseConfiguration from './frontend.js';
+
+var prodConfiguration = Object.assign({}, baseConfiguration);
+prodConfiguration.devtool = 'source-map';
+prodConfiguration.plugins.push(
+  new webpack.optimize.UglifyJsPlugin()
+);
+
+prodConfiguration.module.loaders.push(
+  {test: /\.(gif|png|jpe?g|svg)$/, loaders: [
+    'url?limit=10240&name=[path][name].[ext]?[hash]',
+    'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false',
+  ],}
+);
+
+export default prodConfiguration;


### PR DESCRIPTION
Steps taken:
- Move bundle specific configuration files to `webpack` directory;
- Create separate frontend build files for prod and dev;
- Exclude slow plugins from dev configuration;
- Use dev configuration directly in devProxy for compilation;

fixes #25 
